### PR TITLE
Fix animus-chat issue 4

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,8 +48,8 @@ class Config:
     def get_letta_client_config(self) -> dict:
         """Get configuration for Letta client"""
         return {
-            "server_url": self.letta_server_url,
-            "api_token": self.letta_api_token
+            "base_url": self.letta_server_url,
+            "token": self.letta_api_token
         }
     
     def save_to_env(self, **kwargs) -> None:


### PR DESCRIPTION
Update Letta client config keys to match Letta SDK requirements.

The previous `server_url` and `api_token` keys were not recognized by the Letta SDK, causing configuration failures. This change renames them to `base_url` and `token` to align with the SDK's expected format.

---
<a href="https://cursor.com/background-agent?bcId=bc-b48452b9-0cda-461d-a41d-484010d1a39b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b48452b9-0cda-461d-a41d-484010d1a39b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

