### PR TITLE
Fix animus-chat issue and submit PR

### DIFF
--- a/letta_api.py
+++ b/letta_api.py
@@ -32,7 +32,8 @@ class LettaClient:
             base_url=config.letta_server_url,
             token=config.letta_api_token
         )
-        self.current_agent_id = config.default_agent_id
+        # Ensure we never store None for current_agent_id
+        self.current_agent_id = config.default_agent_id or ""
     
     def test_connection(self) -> bool:
         """Test connection to Letta server"""


### PR DESCRIPTION
Default `LettaClient.current_agent_id` to an empty string to prevent `None` values when `default_agent_id` is unset, resolving #5.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb9ea8e0-85a3-4d1a-bcb1-c121f41f1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb9ea8e0-85a3-4d1a-bcb1-c121f41f1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

